### PR TITLE
Add python-azuracast-monitor and greedy-shark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Tools to help you communicate and engage with your audience.
 
 - **[AzuraCast Player](https://github.com/PeWe79/AzuraCast-Player)** (FOSS): A full-featured interactive web player that uses AzuraCast's API to display rich metadata for multiple stations in a single interface.
 
+- **[python-azuracast-monitor](https://github.com/joemcmahon/python-azuracast-monitor)** (FOSS): A simple Python SSE client that posts the now-playing information to a channel on your Discord.
+
+- **[Greedy Shark](https://github.com/joemcmahon/greedy-shark)** (FOSS): A "dead air" monitor for Azuracast. Samples the stream and posts a broadcast message to a channel on your Discord to alert you if the stream goes silent for more than two minutes.
+
 ## Station Discovery
 Web sites and tools to promote your own station or to find others you may enjoy.
 


### PR DESCRIPTION
A pair of Discord integrations to help monitor the stream and give listeners information about what's playing.

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
n/a

**Proposed changes:**
Adds two entries to the `Communications Tools` section; utility scripts integrating with Discord.
